### PR TITLE
CH33300: Task usage monitoring

### DIFF
--- a/account_usage_dashboard.dashboard.lookml
+++ b/account_usage_dashboard.dashboard.lookml
@@ -761,7 +761,7 @@
     model: snowflake_usage_block
     explore: query_history
     type: looker_bar
-    fields: [query_history.user_name, query_history.average_execution_time, query_history.median_queued_overload_time]
+    fields: [query_history.user_name, query_history.average_execution_time]
     filters:
       query_history.start_date: 1 months
     sorts: [query_history.average_execution_time desc]

--- a/query_history.view.lkml
+++ b/query_history.view.lkml
@@ -1,40 +1,162 @@
 view: query_history {
   sql_table_name: SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY ;;
 
-  dimension: compilation_time {
-    type: string
-    sql: ${TABLE}.COMPILATION_TIME ;;
-  }
-
   dimension: looker_query_context {
     type: string
     hidden: yes
     sql: PARSE_JSON(regexp_substr(regexp_substr(query_text, 'Query\\sContext\\s\'\{.*\}\''),'\{.*\}')) ;;
+    group_label: "Looker Context"
   }
 
   dimension: looker_history_id {
     type: number
     sql: ${looker_query_context}:history_id ;;
+    value_format_name: decimal_0
+    group_label: "Looker Context"
   }
 
   dimension: looker_user_id {
     type: number
     sql: ${looker_query_context}:user_id ;;
+    value_format_name: decimal_0
+    group_label: "Looker Context"
   }
-#   dimension: database_id {
-#     type: number
-#     # hidden: yes
-#     sql: ${TABLE}.DATABASE_ID ;;
-#   }
+
+  dimension: query_id {
+    type: string
+    sql: ${TABLE}.query_id ;;
+    group_label: "Query"
+  }
+
+  dimension: query_text {
+    type: string
+    sql: ${TABLE}.query_text ;;
+    group_label: "Query"
+  }
+
+  dimension: query_type {
+    type: string
+    sql: ${TABLE}.query_type ;;
+    group_label: "Query"
+  }
+
+  dimension: query_tag {
+    type: string
+    sql: ${TABLE}.query_tag ;;
+    group_label: "Query"
+  }
+
+  dimension: database_id {
+    type: number
+    hidden: yes
+    sql: ${TABLE}.database_id ;;
+    value_format_name: decimal_0
+    group_label: "Context"
+ }
 
   dimension: database_name {
     type: string
-    sql: ${TABLE}.DATABASE_NAME ;;
+    sql: ${TABLE}.database_name ;;
+    group_label: "Context"
+  }
+
+  dimension: schema_id {
+    type: number
+    hidden: yes
+    sql: ${TABLE}.schema_id ;;
+    value_format_name: decimal_0
+    group_label: "Context"
   }
 
   dimension: schema_name {
     type: string
-    sql: ${TABLE}.SCHEMA_NAME ;;
+    sql: ${TABLE}.schema_name ;;
+    group_label: "Context"
+  }
+
+  dimension: session_id {
+    type: number
+    sql: ${TABLE}.session_id ;;
+    value_format_name: decimal_0
+    group_label: "Context"
+  }
+
+  dimension: user_name {
+    type: string
+    sql: ${TABLE}.user_name ;;
+    group_label: "Context"
+  }
+
+  dimension: role_name {
+    type: string
+    sql: ${TABLE}.role_name ;;
+    group_label: "Context"
+  }
+
+  dimension: warehouse_id {
+    type: number
+    hidden: yes
+    sql: ${TABLE}.warehouse_id ;;
+    value_format_name: decimal_0
+    group_label: "Context"
+  }
+
+  dimension: warehouse_name {
+    type: string
+    sql: ${TABLE}.warehouse_name ;;
+    group_label: "Context"
+  }
+
+  dimension: warehouse_size {
+    type: string
+    sql: ${TABLE}.warehouse_size ;;
+    group_label: "Context"
+  }
+
+  dimension: warehouse_type {
+    type: string
+    sql: ${TABLE}.warehouse_type ;;
+    group_label: "Context"
+  }
+
+  dimension: cluster_number {
+    type: number
+    sql: ${TABLE}.cluster_number ;;
+    value_format_name: decimal_0
+    group_label: "Context"
+  }
+
+  dimension: execution_status {
+    type: string
+    sql: INITCAP(${TABLE}.execution_status) ;;
+    group_label: "Execution"
+  }
+
+  dimension: error_code {
+    type: string
+    sql: ${TABLE}.error_code ;;
+    group_label: "Execution"
+  }
+
+  dimension: error_message {
+    type: string
+    sql: ${TABLE}.error_message ;;
+    group_label: "Execution"
+  }
+
+  dimension_group: start {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}.start_time ;;
+    label: "Date -  Start"
   }
 
   dimension_group: end {
@@ -48,141 +170,12 @@ view: query_history {
       quarter,
       year
     ]
-    sql: ${TABLE}.END_TIME ;;
-  }
-
-  dimension: error_code {
-    type: string
-    sql: ${TABLE}.ERROR_CODE ;;
-  }
-
-  dimension: error_message {
-    type: string
-    sql: ${TABLE}.ERROR_MESSAGE ;;
-  }
-
-  dimension: execution_status {
-    type: string
-    sql: ${TABLE}.EXECUTION_STATUS ;;
-  }
-
-  dimension: execution_time {
-    type: number
-    sql: ${TABLE}.EXECUTION_TIME ;;
-  }
-
-  dimension: execution_time_tier {
-    type: tier
-    tiers: [1000,2500,5000,10000,25000,50000,100000]
-  }
-
-#   dimension: job_tag {
-#     type: string
-#     sql: ${TABLE}.JOB_TAG ;;
-#   }
-
-  dimension: query_id {
-    type: string
-    primary_key: yes
-    sql: ${TABLE}.QUERY_ID ;;
-  }
-
-  dimension: query_tag {
-    type: string
-    sql: ${TABLE}.QUERY_TAG ;;
-  }
-
-  dimension: query_text {
-    type: string
-    sql: ${TABLE}.QUERY_TEXT ;;
-  }
-
-  dimension: query_type {
-    type: string
-    sql: ${TABLE}.QUERY_TYPE ;;
-  }
-
-  dimension: queued_overload_time {
-    type: number
-    sql: ${TABLE}.QUEUED_OVERLOAD_TIME ;;
-  }
-
-  dimension: has_overload_time {
-    type: yesno
-    sql: ${queued_overload_time}>0 ;;
-  }
-
-  dimension: queued_provisioning_time {
-    type: string
-    sql: ${TABLE}.QUEUED_PROVISIONING_TIME ;;
-  }
-
-  dimension: queued_repair_time {
-    type: string
-    sql: ${TABLE}.QUEUED_REPAIR_TIME ;;
-  }
-
-  dimension: role_name {
-    type: string
-    sql: ${TABLE}.ROLE_NAME ;;
-  }
-
-  dimension: session_id {
-    type: number
-    sql: ${TABLE}.SESSION_ID ;;
-  }
-
-  dimension_group: start {
-    type: time
-    timeframes: [
-      raw,
-      time,
-      second,
-      minute,
-      minute10,
-      date,
-      week,
-      day_of_month,
-      day_of_week,
-      month_name,
-      month,
-      quarter,
-      year
-    ]
-    sql: ${TABLE}.START_TIME ;;
-  }
-
-  dimension: elapsed_time {
-    type: number
-    sql: ${TABLE}.TOTAL_ELAPSED_TIME ;;
-  }
-
-  dimension: transaction_blocked_time {
-    type: string
-    sql: ${TABLE}.TRANSACTION_BLOCKED_TIME ;;
-  }
-
-  dimension: user_name {
-    type: string
-    sql: ${TABLE}.USER_NAME ;;
-  }
-
-  dimension: warehouse_name {
-    type: string
-    sql: ${TABLE}.WAREHOUSE_NAME ;;
-  }
-
-  dimension: warehouse_size {
-    type: string
-    sql: ${TABLE}.WAREHOUSE_SIZE ;;
-  }
-
-  dimension: warehouse_type {
-    type: string
-    sql: ${TABLE}.WAREHOUSE_TYPE ;;
+    sql: ${TABLE}.end_time ;;
+    label: "Date - End"
   }
 
   dimension: is_prior_month_mtd {
+    hidden: yes
     type: yesno
     sql:  EXTRACT(month, ${start_raw}) = EXTRACT(month, current_timestamp()) - 1
             and ${start_raw} <= dateadd(month, -1, current_timestamp())  ;;
@@ -193,6 +186,7 @@ view: query_history {
     drill_fields: [detail*]
     alias: [job_count]
     link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
+    group_label: "Counts"
   }
 
   measure: current_mtd_query_count {
@@ -201,6 +195,7 @@ view: query_history {
     alias: [current_mtd_job_count, current_month_job_count]
     drill_fields: [user_name,warehouse_name,database_name,current_mtd_query_count]
     link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
+    group_label: "Counts"
   }
 
   measure: prior_month_total_query_count {
@@ -209,6 +204,7 @@ view: query_history {
     value_format_name: decimal_0
     alias: [prior_month_total_job_count]
     link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
+    group_label: "Counts"
   }
 
   measure: prior_mtd_query_count {
@@ -217,96 +213,185 @@ view: query_history {
     value_format_name:  decimal_0
     alias: [prior_mtd_job_count, prior_month_job_count]
     link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
+    group_label: "Counts"
   }
 
-  measure: average_execution_time {
+  measure: average_elapsed_time {
     type: average
-    group_label: "Runtime Metrics"
-    sql: ${execution_time} ;;
+    sql: ${TABLE}.total_elapsed_time ;;
     value_format_name: decimal_2
-  }
-
-  measure: total_execution_time {
-    type: sum
-    group_label: "Runtime Metrics"
-    sql: ${execution_time} ;;
-    value_format_name: decimal_2
-  }
-
-  measure: total_queued_overload_time {
-    type: sum
-    group_label: "Runtime Metrics"
-    sql: ${queued_overload_time} ;;
-    filters: { field: has_overload_time value: "Yes" }
-    value_format_name: decimal_2
-    link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
-  }
-
-  measure: median_queued_overload_time {
-    type: median
-    group_label: "Runtime Metrics"
-    sql: 1.0*${queued_overload_time} ;;
-    value_format_name: decimal_2
-    filters: { field: has_overload_time value: "Yes" }
-    drill_fields: [query_id, query_type, query_text, looker_query_context, execution_time, queued_overload_time, start_time, end_time, database_name, warehouse_name, user_name]
-    link: { label: "Warehouse Breakdown" url: "{% if warehouse_name._in_query %}{% else %}{{hidden_drill_warehouse_name_breakdown._link}}&vis=%7B%22color_application%22%3A%7B%22collection_id%22%3A%226c27c30e-5523-4080-82ae-272146e699d0%22%2C%22palette_id%22%3A%2287654122-8144-4720-8259-82ac9908d5f4%22%2C%22options%22%3A%7B%22steps%22%3A5%7D%7D%2C%22x_axis_gridlines%22%3Afalse%2C%22y_axis_gridlines%22%3Atrue%2C%22show_view_names%22%3Afalse%2C%22y_axes%22%3A%5B%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22left%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.query_count%22%2C%22id%22%3A%22query_history.query_count%22%2C%22name%22%3A%22Query+Count%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A0%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3A%22%22%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.average_execution_time%22%2C%22id%22%3A%22query_history.average_execution_time%22%2C%22name%22%3A%22Average+Execution+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%2C%7B%22label%22%3Anull%2C%22orientation%22%3A%22right%22%2C%22series%22%3A%5B%7B%22axisId%22%3A%22query_history.median_queued_overload_time%22%2C%22id%22%3A%22query_history.median_queued_overload_time%22%2C%22name%22%3A%22Median+Queued+Overload+Time%22%7D%5D%2C%22showLabels%22%3Atrue%2C%22showValues%22%3Atrue%2C%22unpinAxis%22%3Afalse%2C%22tickDensity%22%3A%22default%22%2C%22tickDensityCustom%22%3A46%2C%22type%22%3A%22linear%22%7D%5D%2C%22show_y_axis_labels%22%3Atrue%2C%22show_y_axis_ticks%22%3Atrue%2C%22y_axis_tick_density%22%3A%22default%22%2C%22y_axis_tick_density_custom%22%3A5%2C%22show_x_axis_label%22%3Atrue%2C%22show_x_axis_ticks%22%3Atrue%2C%22y_axis_scale_mode%22%3A%22linear%22%2C%22x_axis_reversed%22%3Afalse%2C%22y_axis_reversed%22%3Afalse%2C%22size_by_field%22%3A%22query_history.median_queued_overload_time%22%2C%22plot_size_by_field%22%3Atrue%2C%22trellis%22%3A%22%22%2C%22stacking%22%3A%22%22%2C%22limit_displayed_rows%22%3Afalse%2C%22hidden_series%22%3A%5B%5D%2C%22legend_position%22%3A%22center%22%2C%22series_types%22%3A%7B%22query_history.median_queued_overload_time%22%3A%22scatter%22%2C%22query_history.query_count%22%3A%22column%22%2C%22query_history.average_execution_time%22%3A%22area%22%7D%2C%22point_style%22%3A%22circle%22%2C%22series_colors%22%3A%7B%22query_history.average_execution_time%22%3A%22%23D5DB61%22%2C%22query_history.query_count%22%3A%22%2325435A%22%7D%2C%22series_point_styles%22%3A%7B%22query_history.average_execution_time%22%3A%22square%22%7D%2C%22show_value_labels%22%3Afalse%2C%22label_density%22%3A25%2C%22x_axis_scale%22%3A%22auto%22%2C%22y_axis_combined%22%3Atrue%2C%22show_null_points%22%3Afalse%2C%22interpolation%22%3A%22linear%22%2C%22discontinuous_nulls%22%3Atrue%2C%22ordering%22%3A%22none%22%2C%22show_null_labels%22%3Afalse%2C%22show_totals_labels%22%3Afalse%2C%22show_silhouette%22%3Afalse%2C%22totals_color%22%3A%22%23808080%22%2C%22type%22%3A%22looker_line%22%7D{% endif %}"}
+    group_label: "Runtime"
   }
 
   measure: total_elapsed_time {
     type: sum
-    group_label: "Runtime Metrics"
-    sql: ${elapsed_time} ;;
+    sql: ${TABLE}.total_elapsed_time ;;
     value_format_name: decimal_2
+    group_label: "Runtime"
   }
 
-  measure: total_queued_repair_time  {
-    type: sum
-    group_label: "Runtime Metrics"
-    sql: ${queued_repair_time} ;;
+  measure: average_compilation_time {
+    type: average
+    sql: ${TABLE}.compilation_time ;;
     value_format_name: decimal_2
+    group_label: "Runtime"
   }
 
-  measure: total_compilation_time  {
+  measure: total_compilation_time {
     type: sum
-    group_label: "Runtime Metrics"
-    sql: ${compilation_time} ;;
+    sql: ${TABLE}.compilation_time ;;
     value_format_name: decimal_2
+    group_label: "Runtime"
   }
 
-  measure: total_queued_provisioning_time  {
-    type: sum
-    group_label: "Runtime Metrics"
-    sql: ${queued_provisioning_time} ;;
+  measure: average_execution_time {
+    type: average
+    sql: ${TABLE}.execution_time ;;
     value_format_name: decimal_2
+    group_label: "Runtime"
   }
-  measure: total_transaction_blocked_time  {
+
+  measure: total_execution_time {
     type: sum
-    group_label: "Runtime Metrics"
-    sql: ${transaction_blocked_time} ;;
+    sql: ${TABLE}.execution_time ;;
     value_format_name: decimal_2
+    group_label: "Runtime"
   }
 
   measure: current_mtd_avg_exec_time {
     type: average
-    sql: ${execution_time} ;;
-    group_label: "Runtime Metrics"
+    sql: ${TABLE}.execution_time ;;
     filters: {field: start_date value: "this month"}
     value_format_name: decimal_2
     drill_fields: [user_name,warehouse_name,database_name,current_mtd_avg_exec_time]
+    group_label: "Runtime"
   }
 
   measure: prior_mtd_avg_exec_time {
     type:  average
-    sql:  ${execution_time} ;;
-    group_label: "Runtime Metrics"
+    sql: ${TABLE}.execution_time ;;
     filters: {field: is_prior_month_mtd value: "yes"}
     value_format_name: decimal_2
+    group_label: "Runtime"
+  }
+
+  measure: total_bytes_scanned {
+    type: sum
+    sql:${TABLE}.bytes_scanned ;;
+    value_format_name: decimal_0
+    group_label: "Bytes"
+  }
+
+  measure: average_bytes_scanned {
+    type: average
+    sql:${TABLE}.bytes_scanned ;;
+    value_format_name: decimal_2
+    group_label: "Bytes"
+  }
+
+  measure: total_bytes_written {
+    type: sum
+    sql:${TABLE}.bytes_written ;;
+    value_format_name: decimal_0
+    group_label: "Bytes"
+  }
+
+  measure: average_bytes_written {
+    type: average
+    sql:${TABLE}.bytes_written ;;
+    value_format_name: decimal_2
+    group_label: "Bytes"
+  }
+
+  measure: total_bytes_deleted {
+    type: sum
+    sql:${TABLE}.bytes_deleted ;;
+    value_format_name: decimal_0
+    group_label: "Bytes"
+  }
+
+  measure: average_bytes_deleted {
+    type: average
+    sql:${TABLE}.bytes_deleted ;;
+    value_format_name: decimal_2
+    group_label: "Bytes"
+  }
+
+  measure: total_rows_produced {
+    type: sum
+    sql:${TABLE}.rows_produced ;;
+    value_format_name: decimal_0
+    group_label: "Rows"
+  }
+
+  measure: average_rows_produced {
+    type: average
+    sql:${TABLE}.rows_produced ;;
+    value_format_name: decimal_2
+    group_label: "Rows"
+  }
+
+  measure: total_rows_inserted {
+    type: sum
+    sql:${TABLE}.rows_inserted ;;
+    value_format_name: decimal_0
+    group_label: "Rows"
+  }
+
+  measure: average_rows_inserted {
+    type: average
+    sql:${TABLE}.rows_inserted ;;
+    value_format_name: decimal_2
+    group_label: "Rows"
+  }
+
+  measure: total_rows_updated {
+    type: sum
+    sql:${TABLE}.rows_updated ;;
+    value_format_name: decimal_0
+    group_label: "Rows"
+  }
+
+  measure: average_rows_updated {
+    type: average
+    sql:${TABLE}.rows_updated ;;
+    value_format_name: decimal_2
+    group_label: "Rows"
+  }
+
+  measure: total_rows_deleted {
+    type: sum
+    sql:${TABLE}.rows_deleted ;;
+    value_format_name: decimal_0
+    group_label: "Rows"
+  }
+
+  measure: average_rows_deleted {
+    type: average
+    sql:${TABLE}.rows_deleted ;;
+    value_format_name: decimal_2
+    group_label: "Rows"
+  }
+
+  measure: total_rows_unloaded {
+    type: sum
+    sql:${TABLE}.rows_unloaded ;;
+    value_format_name: decimal_0
+    group_label: "Rows"
+  }
+
+  measure: average_rows_unloaded {
+    type: average
+    sql:${TABLE}.rows_unloaded ;;
+    value_format_name: decimal_2
+    group_label: "Rows"
   }
 
   measure: hidden_drill_warehouse_name_breakdown {
+    hidden: yes
     type: sum
     sql: null ;;
-    drill_fields: [warehouse_name, query_count, average_execution_time, median_queued_overload_time]
+    drill_fields: [warehouse_name, query_count, average_execution_time]
   }
 
   # ----- Sets of fields for drilling ------

--- a/query_history.view.lkml
+++ b/query_history.view.lkml
@@ -24,6 +24,7 @@ view: query_history {
 
   dimension: query_id {
     type: string
+    primary_key: yes
     sql: ${TABLE}.query_id ;;
     group_label: "Query"
   }

--- a/snowflake_usage_block.model.lkml
+++ b/snowflake_usage_block.model.lkml
@@ -122,6 +122,9 @@ explore: task_history {
     from: query_history
     type: left_outer
     relationship: one_to_many
+    # This join logic assumes there is only one level of hierarchical queries
+    # and covers the case of a task using a procedure that runs several queries.
+    # For more complex scenarios the logic should be revisited.
     sql_on: ${parent_query_history.session_id} = ${children_query_history.session_id}
       AND ${parent_query_history.query_id} != ${children_query_history.query_id}
       AND ${children_query_history.start_raw} BETWEEN ${parent_query_history.start_raw} AND ${parent_query_history.end_raw}

--- a/snowflake_usage_block.model.lkml
+++ b/snowflake_usage_block.model.lkml
@@ -106,20 +106,37 @@ explore: table_storage_metrics {
 # explore: views {}
 
 explore: task_history {
-  join: query_history {
+  always_filter: {
+    filters: [
+      task_history.scheduled_date: "7 days"
+    ]
+  }
+  join: parent_query_history {
+    from: query_history
     type: left_outer
     relationship: one_to_one
-    sql_on: ${task_history.query_id} = ${query_history.query_id} ;;
+    sql_on: ${task_history.query_id} = ${parent_query_history.query_id} ;;
+    sql_where: {%condition task_history.scheduled_date %} ${parent_query_history.start_date} {% endcondition %} ;;
+  }
+  join: children_query_history {
+    from: query_history
+    type: left_outer
+    relationship: one_to_many
+    sql_on: ${parent_query_history.session_id} = ${children_query_history.session_id}
+      AND ${parent_query_history.query_id} != ${children_query_history.query_id}
+      AND ${children_query_history.start_raw} BETWEEN ${parent_query_history.start_raw} AND ${parent_query_history.end_raw}
+      AND ${children_query_history.end_raw} BETWEEN ${parent_query_history.start_raw} AND ${parent_query_history.end_raw} ;;
+    sql_where: {%condition task_history.scheduled_date %} ${children_query_history.start_date} {% endcondition %} ;;
   }
   join: _squad_schema_mapping {
     type: left_outer
     relationship: many_to_one
-    sql_on: ${query_history.database_name} = ${_squad_schema_mapping.database_name}
-      AND ${query_history.schema_name} = ${_squad_schema_mapping.schema_name} ;;
+    sql_on: ${parent_query_history.database_name} = ${_squad_schema_mapping.database_name}
+      AND ${parent_query_history.schema_name} = ${_squad_schema_mapping.schema_name} ;;
   }
   join: _squad_warehouse_mapping {
     type: left_outer
     relationship: many_to_one
-    sql_on: ${query_history.warehouse_name} = ${_squad_warehouse_mapping.warehouse_name} ;;
+    sql_on: ${parent_query_history.warehouse_name} = ${_squad_warehouse_mapping.warehouse_name} ;;
   }
 }

--- a/snowflake_usage_block.model.lkml
+++ b/snowflake_usage_block.model.lkml
@@ -104,3 +104,22 @@ explore: table_storage_metrics {
 # explore: tables {}
 #
 # explore: views {}
+
+explore: task_history {
+  join: query_history {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${task_history.query_id} = ${query_history.query_id} ;;
+  }
+  join: _squad_schema_mapping {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${query_history.database_name} = ${_squad_schema_mapping.database_name}
+      AND ${query_history.schema_name} = ${_squad_schema_mapping.schema_name} ;;
+  }
+  join: _squad_warehouse_mapping {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${query_history.warehouse_name} = ${_squad_warehouse_mapping.warehouse_name} ;;
+  }
+}

--- a/task_history.view.lkml
+++ b/task_history.view.lkml
@@ -2,6 +2,13 @@ view: task_history {
 
   sql_table_name: snowflake.account_usage.task_history ;;
 
+  dimension: task_run_id {
+    type: string
+    hidden: yes
+    primary_key: yes
+    sql: ${TABLE}.root_task_id || '-' || ${TABLE}.run_id ;;
+  }
+
   dimension: task_name {
     type: string
     sql: ${TABLE}.name ;;
@@ -139,7 +146,7 @@ view: task_history {
 
   measure: run_count {
     type: count_distinct
-    sql: ${TABLE}.root_task_id || '-' || ${TABLE}.run_id ;;
+    sql: ${task_run_id} ;;
     value_format_name: decimal_0
     group_label: "Counts"
   }

--- a/task_history.view.lkml
+++ b/task_history.view.lkml
@@ -157,6 +157,20 @@ view: task_history {
     group_label: "Counts"
   }
 
+  measure: succeeded_run_count {
+    type: count_distinct
+    sql: CASE WHEN ${succeeded} THEN ${task_run_id} END ;;
+    value_format_name: decimal_0
+    group_label: "Counts"
+  }
+
+  measure: failed_run_count {
+    type: count_distinct
+    sql: CASE WHEN NOT ${succeeded} THEN ${task_run_id} END ;;
+    value_format_name: decimal_0
+    group_label: "Counts"
+  }
+
   measure: total_runtime {
     type: sum
     sql: DATEDIFF('seconds', ${TABLE}.query_start_time, ${TABLE}.completed_time) ;;

--- a/task_history.view.lkml
+++ b/task_history.view.lkml
@@ -1,0 +1,161 @@
+view: task_history {
+
+  sql_table_name: snowflake.account_usage.task_history ;;
+
+  dimension: task_name {
+    type: string
+    sql: ${TABLE}.name ;;
+    group_label: "FQN"
+  }
+
+  dimension: database_name {
+    type: string
+    sql: ${TABLE}.database_name ;;
+    group_label: "FQN"
+  }
+
+  dimension: schema_name {
+    type: string
+    sql: ${TABLE}.schema_name ;;
+    group_label: "FQN"
+  }
+
+  dimension: query_id {
+    type: string
+    sql: ${TABLE}.query_id ;;
+    group_label: "Query"
+  }
+
+  dimension: query_text {
+    type: string
+    sql: ${TABLE}.query_text ;;
+    group_label: "Query"
+  }
+
+  dimension: condition_text {
+    type: string
+    sql: ${TABLE}.condition_text ;;
+    group_label: "Execution"
+  }
+
+  dimension: status {
+    type: string
+    sql: INITCAP(${TABLE}.state) ;;
+    group_label: "Execution"
+  }
+
+  dimension: error_code {
+    type: number
+    sql: ${TABLE}.error_code ;;
+    value_format_name: decimal_0
+    group_label: "Execution"
+  }
+
+  dimension: root_task_id {
+    type: string
+    sql: ${TABLE}.root_task_id ;;
+    group_label: "Execution"
+  }
+
+  dimension: graph_version {
+    type: number
+    sql: ${TABLE}.graph_version ;;
+    value_format_name: decimal_0
+    group_label: "Execution"
+  }
+
+  dimension: run_id {
+    type: number
+    sql: ${TABLE}.run_id ;;
+    value_format_name: decimal_0
+    group_label: "Execution"
+  }
+
+  dimension: return_value {
+    type: string
+    sql: ${TABLE}.return_value ;;
+    group_label: "Execution"
+  }
+
+  dimension_group: originally_scheduled {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: TO_TIMESTAMP_LTZ(${TABLE}.run_id, 3) ;;
+    group_label: "Date -    Originally Scheduled"
+  }
+
+  dimension_group: scheduled {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}.scheduled_time ;;
+    group_label: "Date -   Scheduled"
+  }
+
+  dimension_group: query_started {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}.query_start_time ;;
+    group_label: "Date -  Query Started"
+  }
+
+  dimension_group: completed {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}.completed_time ;;
+    group_label: "Date - Completed"
+  }
+
+  measure: run_count {
+    type: count_distinct
+    sql: ${TABLE}.root_task_id || '-' || ${TABLE}.run_id ;;
+    value_format_name: decimal_0
+    group_label: "Counts"
+  }
+
+  measure: total_runtime {
+    type: sum
+    sql: DATEDIFF('seconds', ${TABLE}.query_start_time, ${TABLE}.completed_time) ;;
+    value_format_name: decimal_0
+    group_label: "Runtime"
+  }
+
+  measure: average_runtime {
+    type: average
+    sql: DATEDIFF('seconds', ${TABLE}.query_start_time, ${TABLE}.completed_time) ;;
+    value_format_name: decimal_2
+    group_label: "Runtime"
+  }
+
+}

--- a/task_history.view.lkml
+++ b/task_history.view.lkml
@@ -51,6 +51,12 @@ view: task_history {
     group_label: "Execution"
   }
 
+  dimension: succeeded {
+    type: yesno
+    sql: LOWER(${TABLE}.state) = 'succeeded' ;;
+    group_label: "Execution"
+  }
+
   dimension: error_code {
     type: number
     sql: ${TABLE}.error_code ;;


### PR DESCRIPTION
Clubhouse story [ch33300](https://app.clubhouse.io/findhotel/story/33300/dgs-flattening-monitoring-2-usage-dashboard).

### Why?
We want to monitor the usage of the flattening pipelines.

### What?
Add a view and explore for the `task_history` table of the `account_usage` schema to expose task usage metrics.