### PR TITLE
SC-51909: Add queue time to query history

### DIFF
--- a/query_history.view.lkml
+++ b/query_history.view.lkml
@@ -259,6 +259,20 @@ view: query_history {
     group_label: "Runtime"
   }
 
+  measure: average_queued_time {
+    type: average
+    sql: ${TABLE}.queued_provisioning_time + ${TABLE}.queued_repair_time + ${TABLE}.queued_overload_time ;;
+    value_format_name: decimal_2
+    group_label: "Runtime"
+  }
+
+  measure: total_queued_time {
+    type: sum
+    sql: ${TABLE}.queued_provisioning_time + ${TABLE}.queued_repair_time + ${TABLE}.queued_overload_time ;;
+    value_format_name: decimal_2
+    group_label: "Runtime"
+  }
+
   measure: current_mtd_avg_exec_time {
     type: average
     sql: ${TABLE}.execution_time ;;


### PR DESCRIPTION
Shortcut story [sc-51909](https://app.shortcut.com/findhotel/story/51909/review-snowflake-health-check-results-and-analyse-cost-trend).

### Why?

To be able to report warehouse queue times.

### What?

Add queue times to query history view.